### PR TITLE
Remove ability to select enter and update click events

### DIFF
--- a/src/assets/fabricator/scripts/search.js
+++ b/src/assets/fabricator/scripts/search.js
@@ -13,7 +13,6 @@ module.exports = {
 		this.results = document.getElementById( 'search-results' );
 		this.loop =	document.querySelectorAll( '.f-menu .ds-nav a' );
 
-		this.input.addEventListener( 'change', this.watch.bind( this ), false );
 		this.input.addEventListener( 'keyup', this.watch.bind( this ), false );
 		this.input.addEventListener( 'keypress', this.submit.bind( this ), false );
 	},

--- a/src/assets/fabricator/scripts/search.js
+++ b/src/assets/fabricator/scripts/search.js
@@ -15,6 +15,7 @@ module.exports = {
 
 		this.input.addEventListener( 'change', this.watch.bind( this ), false );
 		this.input.addEventListener( 'keyup', this.watch.bind( this ), false );
+		this.input.addEventListener( 'keypress', this.submit.bind( this ), false );
 	},
 
 	watch: function() {
@@ -35,6 +36,22 @@ module.exports = {
 			this.clean();
 		}
 
+	},
+
+	/**
+	 * Check which key was press. If `enter`, prevent the default action
+	 *
+	 * @param  {object} e    Base JavaScript event
+	 * @return {object} this
+	 */
+	submit: function( e ) {
+		var key = e.which || e.keyCode;
+
+		if ( key === 13 ) {
+			e.preventDefault();
+		}
+
+		return this;
 	},
 
 	/**


### PR DESCRIPTION
Previously, it took 2 click events to select a link. This was because of a duplicate event. Also, hitting enter triggered a form submission that was unnecessary. 