### PR TITLE
Removing documentation link from the header

### DIFF
--- a/src/views/layouts/includes/f-header-nav.html
+++ b/src/views/layouts/includes/f-header-nav.html
@@ -1,11 +1,6 @@
 <nav class="f-nav" aria-label="primary-nav" role="navigation">
 	<ul class="ds-nav">
 		<li class="ds-nav-item">
-			<a href="#" class="ds-nav-link">
-				Documentation <span class="ds-sr-only"> will trigger a new window or tab.</span>
-			</a>
-		</li>
-		<li class="ds-nav-item">
 			<a href="https://github.com/JDRF/design-system" target="_blank" class="ds-nav-link">
 				Github <span class="ds-sr-only"> will trigger a new window or tab.</span>
 			</a>


### PR DESCRIPTION
This fixes #35 and #42 