### PR TITLE
Replaced address element with non-semantic markup

### DIFF
--- a/src/html/card/content-header.html
+++ b/src/html/card/content-header.html
@@ -4,11 +4,11 @@
 		<img class="ds-card-img" data-src="..." alt="Card image cap">
 	</div>
 	<div class="ds-card-block">
-		<address class="ds-text-muted">
+		<div class="ds-text-address ds-text-muted">
 			<strong>Mission St. Walgreens</strong><br>
 			456 Mission St.<br>
 			San Francisco, CA 94106<br>
 			<a href="#">Directions</a>
-		</address>
+		</div>
 	</div>
 </div>

--- a/src/materials/components/cards.html
+++ b/src/materials/components/cards.html
@@ -97,12 +97,12 @@ notes: |
 				<img class="ds-card-img" data-src="holder.js/100px180" alt="Card image cap" src="data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22672%22%20height%3D%22350%22%20viewBox%3D%220%200%20318%20180%22%20preserveAspectRatio%3D%22none%22%3E%3C!--%0ASource%20URL%3A%20holder.js%2F100px180%2F%3Ftext%3DImage%20cap%0ACreated%20with%20Holder.js%202.8.2.%0ALearn%20more%20at%20http%3A%2F%2Fholderjs.com%0A(c)%202012-2015%20Ivan%20Malopinsky%20-%20http%3A%2F%2Fimsky.co%0A--%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%3C!%5BCDATA%5B%23holder_1552c855e7e%20text%20%7B%20fill%3Argba(255%2C255%2C255%2C.75)%3Bfont-weight%3Anormal%3Bfont-family%3AHelvetica%2C%20monospace%3Bfont-size%3A16pt%20%7D%20%5D%5D%3E%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_1552c855e7e%22%3E%3Crect%20width%3D%22318%22%20height%3D%22180%22%20fill%3D%22%23777%22%2F%3E%3Cg%3E%3Ctext%20x%3D%22109.203125%22%20y%3D%2297.2%22%3EImage%20cap%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E">
 			</div>
 			<div class="ds-card-block">
-				<address class="ds-text-muted">
+				<div class="ds-text-address ds-text-muted">
 					<strong>Mission St. Walgreens</strong><br>
 					456 Mission St.<br>
 					San Francisco, CA 94106<br>
 					<a href="#">Directions</a>
-				</address>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Regarding this issue: #87 

The `address` element has been removed and replaced with a non-semantic element (`div`). Also, a address class was applied for address specific styles.

Styles can be found in this PR: #90 