### PR TITLE
Markup and documentation for the Badges component

### DIFF
--- a/src/html/badge/outline.html
+++ b/src/html/badge/outline.html
@@ -1,0 +1,1 @@
+<h3>Heading Three <span class="label label-outline">10</span></h3>

--- a/src/html/badge/outline.html
+++ b/src/html/badge/outline.html
@@ -1,1 +1,1 @@
-<h3>Heading Three <span class="label label-outline">10</span></h3>
+<h3>Heading Three <span class="ds-label ds-label-outline">10</span></h3>

--- a/src/html/badge/size-outline.html
+++ b/src/html/badge/size-outline.html
@@ -1,0 +1,6 @@
+<h1>Heading One <span class="ds-label ds-label-outline">10</span></h1>
+<h2>Heading Two <span class="ds-label ds-label-outline">10</span></h2>
+<h3>Heading Three <span class="ds-label ds-label-outline">10</span></h3>
+<h4>Heading Four <span class="ds-label ds-label-outline">10</span></h4>
+<h5>Heading Five <span class="ds-label ds-label-outline">10</span></h5>
+<h6>Heading Five <span class="ds-label ds-label-outline">10</span></h6>

--- a/src/html/badge/size-outline.html
+++ b/src/html/badge/size-outline.html
@@ -3,4 +3,4 @@
 <h3>Heading Three <span class="ds-label ds-label-outline">10</span></h3>
 <h4>Heading Four <span class="ds-label ds-label-outline">10</span></h4>
 <h5>Heading Five <span class="ds-label ds-label-outline">10</span></h5>
-<h6>Heading Five <span class="ds-label ds-label-outline">10</span></h6>
+<h6>Heading Six <span class="ds-label ds-label-outline">10</span></h6>

--- a/src/html/badge/size-solid.html
+++ b/src/html/badge/size-solid.html
@@ -3,4 +3,4 @@
 <h3>Heading Three <span class="ds-label ds-label-solid">10</span></h3>
 <h4>Heading Four <span class="ds-label ds-label-solid">10</span></h4>
 <h5>Heading Five <span class="ds-label ds-label-solid">10</span></h5>
-<h6>Heading Five <span class="ds-label ds-label-solid">10</span></h6>
+<h6>Heading Six <span class="ds-label ds-label-solid">10</span></h6>

--- a/src/html/badge/size-solid.html
+++ b/src/html/badge/size-solid.html
@@ -1,0 +1,6 @@
+<h1>Heading One <span class="ds-label ds-label-solid">10</span></h1>
+<h2>Heading Two <span class="ds-label ds-label-solid">10</span></h2>
+<h3>Heading Three <span class="ds-label ds-label-solid">10</span></h3>
+<h4>Heading Four <span class="ds-label ds-label-solid">10</span></h4>
+<h5>Heading Five <span class="ds-label ds-label-solid">10</span></h5>
+<h6>Heading Five <span class="ds-label ds-label-solid">10</span></h6>

--- a/src/html/badge/solid.html
+++ b/src/html/badge/solid.html
@@ -1,0 +1,1 @@
+<h3>Heading Three <span class="label label-outline">10</span></h3>

--- a/src/html/badge/solid.html
+++ b/src/html/badge/solid.html
@@ -1,1 +1,1 @@
-<h3>Heading Three <span class="label label-outline">10</span></h3>
+<h3>Heading Three <span class="ds-label ds-label-default">10</span></h3>

--- a/src/html/badge/variations.html
+++ b/src/html/badge/variations.html
@@ -1,0 +1,18 @@
+<ul class="ds-nav ds-nav-inline">
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">1</span></a></li>
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">10</span></a></li>
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">Label</span></a></li>
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">Long Label</span></a></li>
+</ul>
+<ul class="ds-nav ds-nav-inline">
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary">Primary <span class="ds-label ds-label-default">10</span></a></li>
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary-outline">Outline <span class="ds-label ds-label-default">10</span></a></li>
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-flat">Flat <span class="ds-label ds-label-default">10</span></a></li>
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-link">Text <span class="ds-label ds-label-default">10</span></a></li>
+</ul>
+<ul class="ds-nav ds-nav-inline">
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary">Primary <span class="ds-label ds-label-outline">10</span></a></li>
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary-outline">Outline <span class="ds-label ds-label-outline">10</span></a></li>
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-flat">Flat <span class="ds-label ds-label-outline">10</span></a></li>
+	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-link">Text <span class="ds-label ds-label-outline">10</span></a></li>
+</ul>

--- a/src/html/badge/variations.html
+++ b/src/html/badge/variations.html
@@ -1,16 +1,16 @@
-<ul class="ds-nav ds-nav-inline">
+<ul class="ds-nav ds-nav-pills">
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">1</span></a></li>
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">10</span></a></li>
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">Label</span></a></li>
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">Long Label</span></a></li>
 </ul>
-<ul class="ds-nav ds-nav-inline">
+<ul class="ds-nav ds-nav-pills">
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary">Primary <span class="ds-label ds-label-default">10</span></a></li>
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary-outline">Outline <span class="ds-label ds-label-default">10</span></a></li>
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-flat">Flat <span class="ds-label ds-label-default">10</span></a></li>
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-link">Text <span class="ds-label ds-label-default">10</span></a></li>
 </ul>
-<ul class="ds-nav ds-nav-inline">
+<ul class="ds-nav ds-nav-pills">
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary">Primary <span class="ds-label ds-label-outline">10</span></a></li>
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary-outline">Outline <span class="ds-label ds-label-outline">10</span></a></li>
 	<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-flat">Flat <span class="ds-label ds-label-outline">10</span></a></li>

--- a/src/materials/components/badges.html
+++ b/src/materials/components/badges.html
@@ -12,3 +12,11 @@ notes: |
 	</div>
 	{{example 'badge.outline'}}
 </section>
+
+<section class="f-section">
+	<h3 class="f-example-title">Outline</h3>
+	<div class="f-example">
+		<h3>Heading Three <span class="ds-label ds-label-default">10</span></h3>
+	</div>
+	{{example 'badge.solid'}}
+</section>

--- a/src/materials/components/badges.html
+++ b/src/materials/components/badges.html
@@ -20,3 +20,17 @@ notes: |
 	</div>
 	{{example 'badge.solid'}}
 </section>
+
+<section class="f-section">
+	<h3 class="f-example-title">Sizes</h3>
+	<p>The Badge type size is 75% of the heading type size.</p>
+	<div class="f-example">
+		<h1>Heading One <span class="ds-label ds-label-outline">10</span></h1>
+		<h2>Heading Two <span class="ds-label ds-label-outline">10</span></h2>
+		<h3>Heading Three <span class="ds-label ds-label-outline">10</span></h3>
+		<h4>Heading Four <span class="ds-label ds-label-outline">10</span></h4>
+		<h5>Heading Five <span class="ds-label ds-label-outline">10</span></h5>
+		<h6>Heading Five <span class="ds-label ds-label-outline">10</span></h6>
+	</div>
+	{{example 'badge.size-outline'}}
+</section>

--- a/src/materials/components/badges.html
+++ b/src/materials/components/badges.html
@@ -50,19 +50,19 @@ notes: |
 <section class="f-section">
 	<h3 class="f-example-title">Variations</h3>
 	<div class="f-example">
-		<ul class="ds-nav ds-nav-inline">
+		<ul class="ds-nav ds-nav-pills">
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">1</span></a></li>
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">10</span></a></li>
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">Label</span></a></li>
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">Long Label</span></a></li>
 		</ul>
-		<ul class="ds-nav ds-nav-inline">
+		<ul class="ds-nav ds-nav-pills">
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary">Primary <span class="ds-label ds-label-default">10</span></a></li>
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary-outline">Outline <span class="ds-label ds-label-default">10</span></a></li>
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-flat">Flat <span class="ds-label ds-label-default">10</span></a></li>
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-link">Text <span class="ds-label ds-label-default">10</span></a></li>
 		</ul>
-		<ul class="ds-nav ds-nav-inline">
+		<ul class="ds-nav ds-nav-pills">
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary">Primary <span class="ds-label ds-label-outline">10</span></a></li>
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary-outline">Outline <span class="ds-label ds-label-outline">10</span></a></li>
 			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-flat">Flat <span class="ds-label ds-label-outline">10</span></a></li>

--- a/src/materials/components/badges.html
+++ b/src/materials/components/badges.html
@@ -34,3 +34,15 @@ notes: |
 	</div>
 	{{example 'badge.size-outline'}}
 </section>
+
+<section class="f-section">
+	<div class="f-example">
+		<h1>Heading One <span class="ds-label ds-label-default">10</span></h1>
+		<h2>Heading Two <span class="ds-label ds-label-default">10</span></h2>
+		<h3>Heading Three <span class="ds-label ds-label-default">10</span></h3>
+		<h4>Heading Four <span class="ds-label ds-label-default">10</span></h4>
+		<h5>Heading Five <span class="ds-label ds-label-default">10</span></h5>
+		<h6>Heading Five <span class="ds-label ds-label-default">10</span></h6>
+	</div>
+	{{example 'badge.size-solid'}}
+</section>

--- a/src/materials/components/badges.html
+++ b/src/materials/components/badges.html
@@ -46,3 +46,28 @@ notes: |
 	</div>
 	{{example 'badge.size-solid'}}
 </section>
+
+<section class="f-section">
+	<h3 class="f-example-title">Variations</h3>
+	<div class="f-example">
+		<ul class="ds-nav ds-nav-inline">
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">1</span></a></li>
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">10</span></a></li>
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">Label</span></a></li>
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-h6">Heading Six <span class="ds-label ds-label-outline">Long Label</span></a></li>
+		</ul>
+		<ul class="ds-nav ds-nav-inline">
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary">Primary <span class="ds-label ds-label-default">10</span></a></li>
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary-outline">Outline <span class="ds-label ds-label-default">10</span></a></li>
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-flat">Flat <span class="ds-label ds-label-default">10</span></a></li>
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-link">Text <span class="ds-label ds-label-default">10</span></a></li>
+		</ul>
+		<ul class="ds-nav ds-nav-inline">
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary">Primary <span class="ds-label ds-label-outline">10</span></a></li>
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-primary-outline">Outline <span class="ds-label ds-label-outline">10</span></a></li>
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-flat">Flat <span class="ds-label ds-label-outline">10</span></a></li>
+			<li class="ds-nav-item"><a href="#" class="ds-nav-link ds-btn ds-btn-link">Text <span class="ds-label ds-label-outline">10</span></a></li>
+		</ul>
+	</div>
+	{{example 'badge.variations'}}
+</section>

--- a/src/materials/components/badges.html
+++ b/src/materials/components/badges.html
@@ -30,7 +30,7 @@ notes: |
 		<h3>Heading Three <span class="ds-label ds-label-outline">10</span></h3>
 		<h4>Heading Four <span class="ds-label ds-label-outline">10</span></h4>
 		<h5>Heading Five <span class="ds-label ds-label-outline">10</span></h5>
-		<h6>Heading Five <span class="ds-label ds-label-outline">10</span></h6>
+		<h6>Heading Six <span class="ds-label ds-label-outline">10</span></h6>
 	</div>
 	{{example 'badge.size-outline'}}
 </section>
@@ -42,7 +42,7 @@ notes: |
 		<h3>Heading Three <span class="ds-label ds-label-default">10</span></h3>
 		<h4>Heading Four <span class="ds-label ds-label-default">10</span></h4>
 		<h5>Heading Five <span class="ds-label ds-label-default">10</span></h5>
-		<h6>Heading Five <span class="ds-label ds-label-default">10</span></h6>
+		<h6>Heading Six <span class="ds-label ds-label-default">10</span></h6>
 	</div>
 	{{example 'badge.size-solid'}}
 </section>

--- a/src/materials/components/badges.html
+++ b/src/materials/components/badges.html
@@ -1,0 +1,14 @@
+---
+notes: |
+  The `badges` components are based on Bootstrap's label classes combined with our own customizations. In Bootstrap version 4, `badges` are replaced with `labels`.
+
+  You can find documentation on <a href="https://v4-alpha.getbootstrap.com/components/label/" target="_blank">Bootstrap's label components</a> on their site.
+---
+
+<section class="f-section">
+	<h3 class="f-example-title">Outline</h3>
+	<div class="f-example">
+		<h3>Heading Three <span class="ds-label ds-label-outline">10</span></h3>
+	</div>
+	{{example 'badge.outline'}}
+</section>


### PR DESCRIPTION
The name of the component is based off Bootstrap v3's Badges component, but was refactored in [Bootstrap v4 as the Labels component](https://v4-alpha.getbootstrap.com/components/label/). These updates are customizations to fit JDRF.

Updates in this PR:
1. The HTML and instructions for the Badges.
2. Variation examples of the Badges in other components such as Buttons.

Styles can be found in this PR: #140 