### PR TITLE
Updating Elevation documentation

### DIFF
--- a/src/html/elevations/elevations.html
+++ b/src/html/elevations/elevations.html
@@ -1,5 +1,6 @@
-<div class="ds-elevation-one"></div>
-<div class="ds-elevation-two"></div>
-<div class="ds-elevation-three"></div>
-<div class="ds-elevation-four"></div>
-<div class="ds-elevation-five"></div>
+<div class="ds-elevation-remove"></div>
+<div class="ds-elevation-1"></div>
+<div class="ds-elevation-2"></div>
+<div class="ds-elevation-3"></div>
+<div class="ds-elevation-4"></div>
+<div class="ds-elevation-5"></div>

--- a/src/materials/layout/elevation.html
+++ b/src/materials/layout/elevation.html
@@ -1,12 +1,22 @@
 ---
 notes: |
-  Elevations are applied using the `ds-elevation-` class and are numbered one to five. `.ds-elevation-one` would be the lowest ds-elevation versus `.ds-elevation-five` is the highest.
+  JDRF websites are primarily flat.  Components that require special attention, such as cards and buttons, have subtle elevations to increase contrast with their surroundings and invite interaction.
 
-  Buttons in most cases start with `.ds-elevation-one` and raise to `.ds-elevation-three` on `:hover`, `:focus` and `:active` states. The `.ds-btn-flat` style of buttons start with no elevation and raise to `.ds-elevation-two` on `:hover`, `:focus` and `:active` states.
+  Elevations are applied using the `ds-elevation-` class and are numbered 1 to 5. `.ds-elevation-1` is the lowest and `.ds-elevation-5` is the highest.
 
-  There is a "flat" state not pictured below. Currently the `.ds-btn-flat` buttons are flat (without box shadows) in their normal state. To remove elevations on a button that isn't flat by default, you can use the `@include elevation-remove;` Sass mixin.
+  Buttons in most cases start with `.ds-elevation-1` and raise to `.ds-elevation-3` on `:hover`, `:focus` and `:active` states. The `.ds-btn-flat` style of buttons start with no elevation and raise to `.ds-elevation-two` on `:hover`, `:focus` and `:active` states.
+
+  To remove elevations on a component that isn't flat by default, you can use the `@include elevation-remove;` Sass mixin.
+
+   Modals, dialogs and menus (coming soon to the Design System) are the rare objects that require higher elevations.
+   
 ---
 
+<div class="f-example-inline">
+	<div class="f-rectangle ds-elevation-remove"></div>
+
+	<p class="f-example-desc">flat</p>
+</div>
 <div class="f-example-inline">
 	<div class="f-rectangle ds-elevation-one"></div>
 


### PR DESCRIPTION
- Added a bit more detail about how elevation is used on JDRF websites
- Added the "flat" example.  It seemed odd to reference it in the notes when we can just show it.
- Updated the HTML to use numbers instead of words (5 not five)