### PR TITLE
Resolved Card Subtitle padding issue - Moved styles

### DIFF
--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -70,8 +70,6 @@
 }
 
 .card-subtitle {
-	padding-top: 1rem;
-	padding-bottom: 0.5rem;
 	font-family: $card-subtitle-font-family;
 	font-size: $card-subtitle-font-size;
 	line-height: $card-subtitle-line-height;
@@ -196,8 +194,6 @@
 
 	.card-subtitle {
 		margin-bottom: 0.75rem;
-		padding-top: 0;
-		padding-bottom: 0;
 
 		+ .btn {
 			margin-top: 0.25rem;
@@ -319,6 +315,14 @@
 			display: table;
 			table-layout: fixed;
 		}
+	}
+}
+
+// Image cap card
+.card-image-cap {
+	.card-subtitle {
+		padding-top: 1rem;
+		padding-bottom: 0.5rem;
 	}
 }
 


### PR DESCRIPTION
The global Card Subtitle had top and bottom padding that was only required on the Image Cap card. I took out it out from the global class and moved it into an Image Cap card specific class.