### PR TITLE
Resolved Card Subtitle padding issue - Add class

### DIFF
--- a/src/html/card/image-cap.html
+++ b/src/html/card/image-cap.html
@@ -1,4 +1,4 @@
-<div class="ds-card">
+<div class="ds-card ds-card-image-cap">
 	<img class="ds-card-img-top" data-src="..." alt="Card image">
 	<div class="ds-card-block">
 		<p class="ds-card-subtitle">Start Date - End Date</p>

--- a/src/materials/components/cards.html
+++ b/src/materials/components/cards.html
@@ -61,7 +61,7 @@ notes: |
 <section class="f-section">
 	<h3 class="f-example-title">Image Cap Cards</h3>
 	<div class="f-example">
-		<div class="ds-card" id="phantom-ds-card-image-cap">
+		<div class="ds-card ds-card-image-cap" id="phantom-ds-card-image-cap">
 			<img class="ds-card-img-top" data-src="" alt="Card image" src="http://placehold.it/780x480/777777/ffffff?text=Image+Cap">
 			<div class="ds-card-block">
 				<p class="ds-card-subtitle">Start Date - End Date</p>


### PR DESCRIPTION
The global Card Subtitle had top and bottom padding that was only required on the Image Cap card. I took out it out from the global class and moved it into an Image Cap card specific class.